### PR TITLE
Fix annoying popup error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-phpactor",
-    "version": "1.1.0",
+    "version": "1.2.1",
     "description": "Phpactor PHP Language Server extension for vscode",
     "main": "lib/extension.js",
     "publisher": "dantleech",
@@ -14,7 +14,7 @@
     ],
     "scripts": {
         "clean": "rimraf lib",
-        "build-vsce": "vsce package --out=artifacts/phpactor.vsix",
+        "build-vsce": "mkdir -p artifacts && vsce package --out=artifacts/phpactor.vsix",
         "build": "npm run compile && npm run build-vsce",
         "prepare": "yarn clean && yarn build",
         "watch": "tsc -watch -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import {
     ServerOptions,
     LanguageClientOptions,
     StreamInfo,
+    RevealOutputChannelOn
 } from "vscode-languageclient";
 
 import * as vscode from "vscode";
@@ -85,13 +86,21 @@ function getServerOptions(config): ServerOptions
 function createClient(config: any): LanguageClient {
     let serverOptions = getServerOptions(config);
 
+    let {verbosity} = config.trace.server;
+    let trace = {
+        "off" : RevealOutputChannelOn.Never,
+        "message" : RevealOutputChannelOn.Warn,
+        "verbose" : RevealOutputChannelOn.Info
+    }
+
     let clientOptions: LanguageClientOptions = {
         documentSelector: [
             { language: LanguageID, scheme: 'file' },
             { language: 'blade', scheme: 'file' },
             { language: LanguageID, scheme: 'untitled' }
         ],
-        initializationOptions: config.config
+        initializationOptions: config.config,
+        revealOutputChannelOn: trace[verbosity]
     };
 
     languageClient = new LanguageClient(


### PR DESCRIPTION
Hello from Brazil.

Hey I see that someone started a feature to debug trace messages between vscode and phpactor language server but was not in the client code, so I opened this pull request.

What this feature do is:  control the popup terminal window show, based on value of **phpactor.trace.server.vebosity**.
![Captura de tela de 2023-04-30 21-23-23](https://user-images.githubusercontent.com/21123883/235386219-3e37b654-da94-4e01-ba5f-2dfeac84de83.png)

set "off" for *phpactor.trace.server* do not popup the terminal window when a request fail.

**Note**: I update the version in package.json and I  add mkdir to help automatically create the artifacts folder too.

---
I have one doubt. I run the phpactor via socket in a virtual machine running Linux, and accessed via socket on windows machine everything worked as expected, but only for tag 0.18.1. This is supposed to be happen or is something related to current refactoring. 