### PR TITLE
chore: update vscode dependency for vsce

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^20.0.0",
-        "@types/vscode": "1.84.2",
+        "@types/vscode": "^1.61.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vscode/test-electron": "^2.1.3",


### PR DESCRIPTION
Changing a fixed dev dependency for @types/vscode that prevented vsce from building the package. Renovate will not try to update a loose dep.